### PR TITLE
Add the crafting grid feature

### DIFF
--- a/src/components/CraftingGridDetail.tsx
+++ b/src/components/CraftingGridDetail.tsx
@@ -1,0 +1,55 @@
+import { Stack, Text, List, Grid } from '@mantine/core';
+import type { GameCraftingGrid } from '../interfaces/crafting_grids.interface';
+
+export interface CraftingGridDetailProps {
+  crafting_grid: GameCraftingGrid;
+}
+
+export default function CraftingGridDetail({ crafting_grid }: CraftingGridDetailProps) {
+  /* ---------------- helpers to render each section ---------------- */
+  const renderSection = (title: string, items: Record<string, number>) => {
+    const entries = Object.entries(items);
+    if (entries.length === 0) return null;
+
+    return (
+      <>
+        <Text fw={600} mt="sm">
+          {title}
+        </Text>
+
+        <List size="sm" withPadding>
+          {entries.map(([name, qty]) => (
+            <List.Item key={name}>
+              {qty}x {name}
+            </List.Item>
+          ))}
+        </List>
+      </>
+    );
+  };
+  const renderSection2 = (title: string, items: Record<string, string>) => {
+    const entries = Object.entries(items);
+    if (entries.length === 0) return null;
+
+    return (
+      <>
+        <Text fw={600} mt="sm">
+          {title}
+        </Text>
+        <Grid mt="sm">
+          {entries.map(([coordinate, item]) => (
+              <Grid.Col  bd="1px solid black" key={coordinate}  h={40} span={4}>{item}</Grid.Col>
+          ))}
+        </Grid>
+      </>
+    );
+  };
+
+  /* ------------------------------ render -------------------------- */
+  return (
+    <Stack gap={2}>
+      {renderSection('Products', crafting_grid.products)}
+      {renderSection2('Crafting coordinates', crafting_grid.crafting_coordinates)}
+    </Stack>
+  );
+}

--- a/src/components/CraftingGridsForItem.tsx
+++ b/src/components/CraftingGridsForItem.tsx
@@ -1,0 +1,47 @@
+import { Grid, Paper, Text, Center } from '@mantine/core';
+import type { GameEntry } from '../interfaces/games.interface';
+import type { GameItem } from '../interfaces/items.interface';
+import type { GameCraftingGrid } from '../interfaces/crafting_grids.interface';
+import { WithUseApi } from './dataviews/WithUseApi';
+import CraftingGridDetail from './CraftingGridDetail';
+import LoadingSpinner from './dataviews/LoadingSpinner';
+
+export interface CraftingGridsForItemProps {
+  game: GameEntry;
+  item: GameItem;
+}
+
+export default function CraftingGridsForItem({ game, item }: CraftingGridsForItemProps) {
+  const {
+    data: crafting_grids,
+    loading,
+    error,
+  } = WithUseApi<GameCraftingGrid[]>(
+    { url: `/api/games/${game.id}/items/${item.id}/craftingGrid`, method: 'GET' },
+    [game, item],
+  );
+
+  if(loading) return <LoadingSpinner />;
+  if(error) return <Text p="md" c="red.6">Error: {error.message}</Text>;
+  if(!crafting_grids) return <Text p="md">Server error</Text>;
+
+  if(crafting_grids.length === 0) {
+    return (
+      <Center h="100%">
+        <Text c="dimmed">No crafting grids found!</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <Grid gutter="md">
+      {crafting_grids.map((crafting_grid) => (
+        <Grid.Col key={crafting_grid.id} span={{ base: 12, sm: 6, md: 4, lg: 4 }}>
+          <Paper p="md" withBorder shadow="xs">
+            <CraftingGridDetail crafting_grid={crafting_grid}/>
+          </Paper>
+        </Grid.Col>
+      ))}
+    </Grid>
+  );
+}

--- a/src/interfaces/crafting_grids.interface.ts
+++ b/src/interfaces/crafting_grids.interface.ts
@@ -1,0 +1,6 @@
+import { type DisplayEntity } from "./entity.interface";
+
+export interface GameCraftingGrid extends DisplayEntity {
+  products: Record<string, number>;
+  crafting_coordinates: Record<string, string>;
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -97,4 +97,79 @@ export const handlers = [
       }});
     }
   }),
+  http.get<{ game_id: string }>('/api/games/:game_id/craftingGrid', () => {
+    return HttpResponse.json(
+      [
+        {
+        "id": 1,
+        "products": {
+            "Item 1": 1
+        },
+        "crafting_coordinates": {
+            "A1": "Item 3",
+            "A2": "Item 3",
+            "A3": "Item 3",
+            "B1": "Item 3",
+            "B2": "",
+            "B3": "Item 3",
+            "C1": "Item 3",
+            "C2": "Item 3",
+            "C3": "Item 3"
+        }
+      },
+      {
+        "id": 2,
+        "products": {
+            "Item 2": 1
+        },
+        "crafting_coordinates": {
+            "A1": "",
+            "A2": "",
+            "A3": "",
+            "B1": "Item 1",
+            "B2": "Item 1",
+            "B3": "",
+            "C1": "Item 1",
+            "C2": "Item 1",
+            "C3": ""
+        }}]);
+  }),
+  
+  http.get<{ game_id: string }>('/api/games/:game_id/items/:item_id/craftingGrid', () => {
+    return HttpResponse.json(
+      [
+        {
+        "id": 1,
+        "products": {
+            "Item 1": 1
+        },
+        "crafting_coordinates": {
+            "A1": "Item 3",
+            "A2": "Item 3",
+            "A3": "Item 3",
+            "B1": "Item 3",
+            "B2": "",
+            "B3": "Item 3",
+            "C1": "Item 3",
+            "C2": "Item 3",
+            "C3": "Item 3"
+        }
+      },
+      {
+        "id": 2,
+        "products": {
+            "Item 2": 1
+        },
+        "crafting_coordinates": {
+            "A1": "",
+            "A2": "",
+            "A3": "",
+            "B1": "Item 1",
+            "B2": "Item 1",
+            "B3": "",
+            "C1": "Item 1",
+            "C2": "Item 1",
+            "C3": ""
+        }}]);
+  }),
 ]

--- a/src/tools/ToolCraftingGrid.tsx
+++ b/src/tools/ToolCraftingGrid.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import {
+  Grid,
+  GridCol,
+  Paper,
+  Box,
+  Text,
+  Center,
+  useMantineTheme,
+} from '@mantine/core';
+import ItemListPanel from '../components/ItemListPanel';
+import type { ToolProps } from '../interfaces/tools.interface';
+import type { GameItem } from '../interfaces/items.interface';
+import CraftingGridsForItem from '../components/CraftingGridsForItem';
+
+export default function ToolBrowseItem({ game }: ToolProps) {
+  const [selectedItem, setSelectedItem] = useState<GameItem | null>(null);
+  const theme = useMantineTheme();
+
+  const headerBorder = `1px solid ${theme.colors.gray[3]}`;
+
+  return (
+    <Box h="calc(100vh - 60px)" p="md">
+      <Grid h="100%" gutter="md" align="stretch" justify="center">
+        {/* Item Panel - left */}
+        <GridCol span={{ base: 12, md: 4, lg: 3 }}>
+          <Paper shadow="sm" h={600} style={{ display: 'flex', flexDirection: 'column' }}>
+            {/* Header */}
+            <Box
+              p="md"
+              style={{
+                borderBottom: headerBorder,
+                background: theme.colors[theme.primaryColor][6],
+                color: theme.white,
+              }}
+            >
+              <Text fw={600}>Items</Text>
+            </Box>
+            
+            {/* Content */}
+            <Box p="md" style={{ flex: 1, overflow: 'auto' }}>
+              <ItemListPanel
+                game={game}
+                onSelect={setSelectedItem}
+              />
+            </Box>
+          </Paper>
+        </GridCol>
+
+        {/* Crafting grid Panel - right */}
+        <GridCol span={{ base: 12, md: 8, lg: 9 }}>
+          <Paper shadow="sm" h={600} style={{ display: 'flex', flexDirection: 'column' }}>
+            {/* Header */}
+            <Box
+              p="md"
+              style={{
+                borderBottom: headerBorder,
+                background: selectedItem ? theme.colors.teal[6] : theme.colors.gray[1],
+                color: selectedItem ? theme.white : theme.black,
+              }}
+            >
+              <Text fw={600}>
+                {selectedItem
+                  ? `Crafting grids for ${selectedItem.name}`
+                  : 'Crafting grid Details'}
+              </Text>
+            </Box>
+
+            {/* Content */}
+            <Box p="md" style={{ flex: 1, overflow: 'auto' }}>
+              {selectedItem ? (
+                <CraftingGridsForItem game={game} item={selectedItem} />
+              ) : (
+                <Center h="100%">
+                  <Box ta="center" c="dimmed">
+                    <Text size="xl" fw={500} mb="xs">
+                      No Item Selected
+                    </Text>
+                    <Text>
+                      Select an item from the list to view its crafting grid details
+                    </Text>
+                  </Box>
+                </Center>
+              )}
+            </Box>
+          </Paper>
+        </GridCol>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/tools/Tools.tsx
+++ b/src/tools/Tools.tsx
@@ -1,6 +1,7 @@
 import type { Tool } from "../interfaces/tools.interface";
 import ToolBrowseItem from "./ToolBrowseItems";
 import ToolIngredientsFor from "./ToolIngredientsFor";
+import ToolCraftingGrid from "./ToolCraftingGrid";
 
 export const tools: Tool[] = [
   {
@@ -17,4 +18,11 @@ export const tools: Tool[] = [
     long_desc: 'Calculate the ingredients required to craft an item.',
     renderToolContent: ToolIngredientsFor
   },
+  {
+    id: 'Crafting grid',
+    name: 'Crafting Grid display',
+    description: 'Browse items and crafting grid recipes',
+    long_desc: 'Display the crafting grid recipe for a chosen item',
+    renderToolContent: ToolCraftingGrid
+  }
 ];


### PR DESCRIPTION
Will resolve this issue: #1 

- [x] My code follows the style guide 
- [x] Unit tests were added
- [ ] Unit tests will be added later after some review
- [ ] Unit tests weren't necessary

Before the features that had been added to crafterlib since the latest update (0.2.1) were not implemented to the frontend server, therefore users could not utilize them. 

I solved this issue by creating a new tool called "ToolCraftingGrid" that displayed the crafting grids in a user-friendly way using grids to show how the item is meant to be crafted. 
